### PR TITLE
ENH: store quantity and units of the volume

### DIFF
--- a/Py/DICOMParametricMapPlugin.py
+++ b/Py/DICOMParametricMapPlugin.py
@@ -1,6 +1,7 @@
 import os
 import string
-import vtk, qt, ctk, slicer
+import json
+import vtk, qt, ctk, slicer, logging
 from DICOMPluginBase import DICOMPluginBase
 from DICOMLib import DICOMLoadable
 
@@ -114,6 +115,13 @@ class DICOMParametricMapPluginClass(DICOMPluginBase):
       return False
 
     (_,pmNode) = slicer.util.loadVolume(os.path.join(self.tempDir,"pmap.nrrd"), returnNode=True)
+
+    # load the metadata JSON to retrieve volume semantics (quantity stored and units)
+    with open(os.path.join(self.tempDir,"meta.json")) as metafile:
+      meta = json.load(metafile)
+      pmNode.SetAttribute("DICOM.QuantityValueCode",str(meta["QuantityValueCode"]))
+      pmNode.SetAttribute("DICOM.MeasurementUnitsCode",str(meta["MeasurementUnitsCode"]))
+      pmNode.SetAttribute("DICOM.instanceUIDs", uid)
 
     # create Subject hierarchy nodes for the loaded series
     self.addSeriesInSubjectHierarchy(loadable, pmNode)


### PR DESCRIPTION
Re #127

Store quantity and units for parametric maps as stringified JSON dictionaries in
DICOM.QuantityValueCode and DICOM.MeasurementUnitsCode.

@pieper @lassoan - can you take a look and let me know what you think about this?

When we agree on the approach, I would like to add similar functionality to the other DICOM plugins (where it makes sense) that load image volumes. It is not always as straightforward as with parametric maps, but when it is not possible to figure out these items, we can just leave those attributes uninitialized. When they are initialized, they would be used by the segment statistics module plugins, and should be useful for other purposes down the road.