### PR TITLE
ENH: integration of SegmentStatistics (issue #168, #161)

### DIFF
--- a/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/DICOMPlugins/DICOMTID1500Plugin.py
@@ -229,9 +229,9 @@ class DICOMTID1500PluginClass(DICOMPluginBase):
         col = table.AddColumn()
 
         if "derivationModifier" in measurementItem.keys():
-          col.SetName(SegmentStatisticsDICOMMeaningMapping.getKeyForValue(measurementItem["derivationModifier"]["CodeMeaning"]))
+          col.SetName(measurementItem["derivationModifier"]["CodeMeaning"])
         else:
-          col.SetName(SegmentStatisticsDICOMMeaningMapping.getKeyForValue(measurementItem["quantity"]["CodeMeaning"] +" "+measurementItem["units"]["CodeValue"]))
+          col.SetName("%s %s" %(measurementItem["quantity"]["CodeMeaning"], measurementItem["units"]["CodeValue"]))
 
       for measurement in data["Measurements"]:
         name = measurement["TrackingIdentifier"]
@@ -245,33 +245,6 @@ class DICOMTID1500PluginClass(DICOMPluginBase):
       slicer.app.applicationLogic().GetSelectionNode().SetReferenceActiveTableID(table.GetID())
       slicer.app.applicationLogic().PropagateTableSelection()
     return table
-
-
-class SegmentStatisticsDICOMMeaningMapping(object):
-
-  mapping = {"GS min": "Minimum",
-             "GS max": "Maximum",
-             "GS mean": "Mean",
-             "GS stdev": "Standard Deviation",
-             "GS volume cc": ("cm3", "Volume cm3"),
-             "GS volume mm3": ("mm3", "Volume mm3")}
-
-  @staticmethod
-  def getValueForKey(name, longVersion=False):
-    try:
-      value = SegmentStatisticsDICOMMeaningMapping.mapping[name]
-      if type(value) is tuple:
-        return value[1 if longVersion else 0]
-      return value
-    except KeyError:
-      return name
-
-  @staticmethod
-  def getKeyForValue(name):
-    for index, value in enumerate(SegmentStatisticsDICOMMeaningMapping.mapping.values()):
-      if name in value:
-        return SegmentStatisticsDICOMMeaningMapping.mapping.keys()[index]
-    return name
 
 
 class DICOMTID1500Plugin:

--- a/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/DICOMPlugins/DICOMTID1500Plugin.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-
+from collections import Counter
 import dicom
 
 import slicer
@@ -211,50 +211,84 @@ class DICOMTID1500PluginClass(DICOMPluginBase):
 
   def metadata2vtkTableNode(self, metafile):
     with open(metafile) as datafile:
-      table = slicer.vtkMRMLTableNode()
-      slicer.mrmlScene.AddNode(table)
-      table.SetAttribute("QuantitativeReporting", "Yes")
-      table.SetAttribute("readonly", "Yes")
-      table.SetUseColumnNameAsColumnHeader(True)
-
       data = json.load(datafile)
+      measurement = data["Measurements"][0]
+
+      table = self.createAndConfigureTable()
 
       tableWasModified = table.StartModify()
-
-      measurement = data["Measurements"][0]
-      col = table.AddColumn()
-      col.SetName("Segment")
-
-      for measurementItem in measurement["measurementItems"]:
-        col = table.AddColumn()
-
-        unit = measurementItem["units"]["CodeValue"]
-        unit = unit if unit != "1" else measurementItem["units"]["CodeMeaning"]
-
-        if "derivationModifier" in measurementItem.keys():
-          description = columnName = measurementItem["derivationModifier"]["CodeMeaning"]
-        else:
-          description = measurementItem["quantity"]["CodeMeaning"]
-          columnName = "%s %s" % (description, unit)
-          description = "%s in %s" % (description, unit)
-
-        col.SetName(columnName)
-        table.SetColumnLongName(columnName, columnName)
-        table.SetColumnUnitLabel(columnName, unit)
-        table.SetColumnDescription(columnName, str(description))
-
-      for measurement in data["Measurements"]:
-        name = measurement["TrackingIdentifier"]
-        value = measurement["ReferencedSegment"]
-        rowIndex = table.AddEmptyRow()
-        table.SetCellText(rowIndex, 0, name)
-        for columnIndex, measurementItem in enumerate(measurement["measurementItems"]):
-          table.SetCellText(rowIndex, columnIndex+1, measurementItem["value"])
-
+      self.setupTableInformation(measurement, table)
+      self.addMeasurementsToTable(data, table)
       table.EndModify(tableWasModified)
+
       slicer.app.applicationLogic().GetSelectionNode().SetReferenceActiveTableID(table.GetID())
       slicer.app.applicationLogic().PropagateTableSelection()
     return table
+
+  def addMeasurementsToTable(self, data, table):
+    for measurement in data["Measurements"]:
+      name = measurement["TrackingIdentifier"]
+      value = measurement["ReferencedSegment"]
+      rowIndex = table.AddEmptyRow()
+      table.SetCellText(rowIndex, 0, name)
+      for columnIndex, measurementItem in enumerate(measurement["measurementItems"]):
+        table.SetCellText(rowIndex, columnIndex + 1, measurementItem["value"])
+
+  def createAndConfigureTable(self):
+    table = slicer.vtkMRMLTableNode()
+    slicer.mrmlScene.AddNode(table)
+    table.SetAttribute("QuantitativeReporting", "Yes")
+    table.SetAttribute("readonly", "Yes")
+    table.SetUseColumnNameAsColumnHeader(True)
+    return table
+
+  def setupTableInformation(self, measurement, table):
+    col = table.AddColumn()
+    col.SetName("Segment")
+
+    infoItems = self.enumerateDuplicateNames(self.generateMeasurementInformation(measurement["measurementItems"]))
+
+    for info in infoItems:
+      col = table.AddColumn()
+      col.SetName(info["name"])
+      table.SetColumnLongName(info["name"], info["name"])
+      table.SetColumnUnitLabel(info["name"], info["unit"])
+      table.SetColumnDescription(info["name"], info["description"])
+
+  def generateMeasurementInformation(self, measurementItems):
+    infoItems = []
+    for measurementItem in measurementItems:
+
+      crntInfo = dict()
+
+      unit = measurementItem["units"]["CodeValue"]
+      crntInfo["unit"] = measurementItem["units"]["CodeMeaning"]
+
+      if "derivationModifier" in measurementItem.keys():
+        description = crntInfo["name"] = measurementItem["derivationModifier"]["CodeMeaning"]
+      else:
+        description = measurementItem["quantity"]["CodeMeaning"]
+
+      crntInfo["name"] = "%s [%s]" % (description, unit.replace("[", "").replace("]", ""))
+      crntInfo["description"] = description
+
+      infoItems.append(crntInfo)
+    return infoItems
+
+  def enumerateDuplicateNames(self, items):
+    names = [item["name"] for item in items]
+    counts = {k: v for k, v in Counter(names).items() if v > 1}
+    nameListCopy = names[:]
+
+    for i in reversed(range(len(names))):
+      item = names[i]
+      if item in counts and counts[item]:
+        nameListCopy[i] += " (%s)" % str(counts[item])
+        counts[item] -= 1
+
+    for idx, item in enumerate(nameListCopy):
+      items[idx]["name"] = item
+    return items
 
 
 class DICOMTID1500Plugin:

--- a/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/DICOMPlugins/DICOMTID1500Plugin.py
@@ -228,10 +228,20 @@ class DICOMTID1500PluginClass(DICOMPluginBase):
       for measurementItem in measurement["measurementItems"]:
         col = table.AddColumn()
 
+        unit = measurementItem["units"]["CodeValue"]
+        unit = unit if unit != "1" else measurementItem["units"]["CodeMeaning"]
+
         if "derivationModifier" in measurementItem.keys():
-          col.SetName(measurementItem["derivationModifier"]["CodeMeaning"])
+          description = columnName = measurementItem["derivationModifier"]["CodeMeaning"]
         else:
-          col.SetName("%s %s" %(measurementItem["quantity"]["CodeMeaning"], measurementItem["units"]["CodeValue"]))
+          description = measurementItem["quantity"]["CodeMeaning"]
+          columnName = "%s %s" % (description, unit)
+          description = "%s in %s" % (description, unit)
+
+        col.SetName(columnName)
+        table.SetColumnLongName(columnName, columnName)
+        table.SetColumnUnitLabel(columnName, unit)
+        table.SetColumnDescription(columnName, str(description))
 
       for measurement in data["Measurements"]:
         name = measurement["TrackingIdentifier"]

--- a/QuantitativeReporting.py
+++ b/QuantitativeReporting.py
@@ -1031,8 +1031,8 @@ class CustomSegmentStatisticsLogic(SegmentStatisticsLogic):
         item["value"] = str(self.statistics[segmentValue, key])
         item["quantity"] = self._createCodeSequence(measurementInfo["DICOM.QuantityCode"])
         item["units"] = self._createCodeSequence(measurementInfo["DICOM.UnitsCode"])
-        if measurementInfo.has_key("DICOM.UnitsCode"):
-          item["derivationModifier"] = self._createCodeSequence(measurementInfo["DICOM.UnitsCode"])
+        if measurementInfo.has_key("DICOM.DerivationCode"):
+          item["derivationModifier"] = self._createCodeSequence(measurementInfo["DICOM.DerivationCode"])
         measurementItems.append(item)
       else:
         logging.info("No measurements found for %s" % key)

--- a/QuantitativeReporting.py
+++ b/QuantitativeReporting.py
@@ -23,8 +23,6 @@ from SlicerDevelopmentToolboxUtils.buttons import CrosshairButton
 
 from SegmentEditor import SegmentEditorWidget
 from SegmentStatistics import SegmentStatisticsLogic, SegmentStatisticsParameterEditorDialog
-from SegmentStatisticsCalculators import ScalarVolumeSegmentStatisticsCalculator
-from SegmentStatisticsCalculators import SegmentStatisticsCalculatorBase
 
 from DICOMLib.DICOMWidgets import DICOMDetailsWidget
 
@@ -879,7 +877,11 @@ class QuantitativeReportingSegmentEditorLogic(ScriptedLoadableModuleLogic):
 
 class CustomSegmentStatisticsLogic(SegmentStatisticsLogic):
 
-  registeredCalculators = [ScalarVolumeSegmentStatisticsCalculator]
+  @staticmethod
+  def getDICOMTriplet(codeValue, codingSchemeDesignator, codeMeaning):
+    return {'CodeValue':codeValue,
+            'CodingSchemeDesignator': codingSchemeDesignator,
+            'CodeMeaning': codeMeaning}
 
   @property
   def statistics(self):
@@ -959,16 +961,16 @@ class CustomSegmentStatisticsLogic(SegmentStatisticsLogic):
     categoryObject = terminologyEntry.GetCategoryObject()
     if categoryObject is None or not self.isTerminologyInformationValid(categoryObject):
       return {}
-    segmentData["SegmentedPropertyCategoryCodeSequence"] = self.getJSONFromVtkSlicerTerminology(categoryObject)
+    segmentData["SegmentedPropertyCategoryCodeSequence"] = self.getJSONFromVTKSlicerTerminology(categoryObject)
 
     typeObject = terminologyEntry.GetTypeObject()
     if typeObject is None or not self.isTerminologyInformationValid(typeObject):
       return {}
-    segmentData["SegmentedPropertyTypeCodeSequence"] = self.getJSONFromVtkSlicerTerminology(typeObject)
+    segmentData["SegmentedPropertyTypeCodeSequence"] = self.getJSONFromVTKSlicerTerminology(typeObject)
 
     modifierObject = terminologyEntry.GetTypeModifierObject()
     if modifierObject is not None and self.isTerminologyInformationValid(modifierObject):
-      segmentData["SegmentedPropertyTypeModifierCodeSequence"] = self.getJSONFromVtkSlicerTerminology(modifierObject)
+      segmentData["SegmentedPropertyTypeModifierCodeSequence"] = self.getJSONFromVTKSlicerTerminology(modifierObject)
 
     return segmentData
 
@@ -979,21 +981,20 @@ class CustomSegmentStatisticsLogic(SegmentStatisticsLogic):
     regionObject = terminologyEntry.GetAnatomicRegionObject()
     if regionObject is None or not self.isTerminologyInformationValid(regionObject):
       return {}
-    segmentData["AnatomicRegionSequence"] = self.getJSONFromVtkSlicerTerminology(regionObject)
+    segmentData["AnatomicRegionSequence"] = self.getJSONFromVTKSlicerTerminology(regionObject)
 
     regionModifierObject = terminologyEntry.GetAnatomicRegionModifierObject()
     if regionModifierObject is not None and self.isTerminologyInformationValid(regionModifierObject):
-      segmentData["AnatomicRegionModifierSequence"] = self.getJSONFromVtkSlicerTerminology(regionModifierObject)
+      segmentData["AnatomicRegionModifierSequence"] = self.getJSONFromVTKSlicerTerminology(regionModifierObject)
     return segmentData
 
   def isTerminologyInformationValid(self, termTypeObject):
     return all(t is not None for t in [termTypeObject.GetCodeValue(), termTypeObject.GetCodingSchemeDesignator(),
                                        termTypeObject.GetCodeMeaning()])
 
-  def getJSONFromVtkSlicerTerminology(self, termTypeObject):
-    return SegmentStatisticsCalculatorBase.getDICOMTriplet(termTypeObject.GetCodeValue(),
-                                                           termTypeObject.GetCodingSchemeDesignator(),
-                                                           termTypeObject.GetCodeMeaning())
+  def getJSONFromVTKSlicerTerminology(self, termTypeObject):
+    return self.getDICOMTriplet(termTypeObject.GetCodeValue(), termTypeObject.GetCodingSchemeDesignator(),
+                                termTypeObject.GetCodeMeaning())
 
   def generateJSON4DcmSR(self, dcmSegmentationFile, sourceVolumeNode):
     measurements = []


### PR DESCRIPTION
fixes #168

* segmentStatisticsConfigButton added for configuring SegmentStatistics
  calculators
  * TODO: this should be moved somewhere else since in FourUp
          Quanitative the Measurements area disappears from main module
          widget

* for now just catching the exception and printing a message
* all quantities/units for which we don't have the code sequence
  definitions yet, won't be added to the output DICOM
  * TODO: add code sequences for handling quantities/units other than
          the currently supported ones only


We can merge this once the new SegmentStatistics additions has been merged to Slicer core