### PR TITLE
ENH: removed LabelmapSegmentStatisticsPlugin from custom statistics

### DIFF
--- a/QuantitativeReporting/QRCustomizations/CustomSegmentStatistics.py
+++ b/QuantitativeReporting/QRCustomizations/CustomSegmentStatistics.py
@@ -1,8 +1,9 @@
 import logging
-
 import slicer
+
 from SlicerDevelopmentToolboxUtils.mixins import ModuleLogicMixin
 from SegmentStatistics import SegmentStatisticsLogic
+from SegmentStatisticsPlugins import ScalarVolumeSegmentStatisticsPlugin, ClosedSurfaceSegmentStatisticsPlugin
 from DICOMSegmentationPlugin import DICOMSegmentationExporter
 
 
@@ -23,6 +24,10 @@ class CustomSegmentStatisticsLogic(SegmentStatisticsLogic):
     return slicer.mrmlScene.GetNodeByID(self.getParameterNode().GetParameter("Segmentation"))
 
   def __init__(self):
+    logging.debug("CustomSegmentStatisticsLogic: only using ScalarVolumeSegmentStatisticsPlugin and "
+                  "ClosedSurfaceSegmentStatisticsPlugin")
+    SegmentStatisticsLogic.registeredPlugins = [ScalarVolumeSegmentStatisticsPlugin,
+                                                ClosedSurfaceSegmentStatisticsPlugin]
     SegmentStatisticsLogic.__init__(self)
     self.terminologyLogic = slicer.modules.terminologies.logic()
 


### PR DESCRIPTION
The reason for removing that plugin from the plugins list is that Measurements were duplicated.

I implemented it the way it's done in the SegmentStatisticsTest [1] although I don't think that it should be implemented that way because it "unregisters" the SegmentStatistics plugins globally since it's set on the SegmentStatisticsLogic class directly. 

Calling SegmentStatistics module afterwards, it only those plugins, that I registered for QuantitativeReporting are displayed, but all others are gone.

[1] https://github.com/Slicer/Slicer/blob/08fec03c10955e813b22886697ee2cdb346898df/Modules/Scripted/SegmentStatistics/SegmentStatistics.py#L829-L832

cc @chribaue 

