### PR TITLE
BUG: replaced obsolete ctkMacroCompilePythonScript (issue #203)

### DIFF
--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -1,9 +1,6 @@
-slicer_add_python_unittest(SCRIPT ${MODULE_NAME}Tests.py)
-
-ctkMacroCompilePythonScript(
-  TARGET_NAME ApplicationSelfTests
-  SCRIPTS "${MODULE_NAME}Tests.py"
-  DESTINATION_DIR ${Slicer_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}
-  INSTALL_DIR ${Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR}
-  NO_INSTALL_SUBDIR
+slicerMacroBuildScriptedModule(
+  NAME ${MODULE_NAME}Tests
+  SCRIPTS ${MODULE_NAME}Tests
 )
+
+slicer_add_python_unittest(SCRIPT ${MODULE_NAME}Tests.py)


### PR DESCRIPTION
with slicer_add_python_unittest and making tests available in module
selector via slicerMacroBuildScriptedModule

is supposed to fix #203