### PR TITLE
BUG: Fix error reporting in segmentation and TID1500 plugins

### DIFF
--- a/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -327,7 +327,7 @@ class DICOMSegmentationPluginClass(DICOMPluginBase):
     try:
       slicer.modules.segmentations
     except AttributeError as exc:
-      return exc.message
+      return str(exc)
 
     shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
     if shNode is None:
@@ -353,14 +353,17 @@ class DICOMSegmentationPluginClass(DICOMPluginBase):
         try:
           exporter.export(exportable.directory, segFileName, metadata)
         except DICOMSegmentationExporter.EmptySegmentsFoundError as exc:
-          if slicer.util.confirmYesNoDisplay(exc.message):
+          if slicer.util.confirmYesNoDisplay(str(exc)):
             exporter.export(exportable.directory, segFileName, metadata, skipEmpty=True)
           else:
             raise ValueError("Export canceled")
         slicer.dicomDatabase.insert(segFilePath)
         logging.info("Added segmentation to DICOM database (" +segFilePath+")")
       except (DICOMSegmentationExporter.NoNonEmptySegmentsFoundError, ValueError) as exc:
-        return exc.message
+        return str(exc)
+      except Exception as exc:
+        # Generic error
+        return "Segmentation object export failed.\n{0}".format(str(exc))
       finally:
         exporter.cleanup()
     return ""

--- a/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/DICOMPlugins/DICOMTID1500Plugin.py
@@ -206,7 +206,7 @@ class DICOMTID1500PluginClass(DICOMPluginBase, ModuleLogicMixin):
       try:
         tid1500reader = slicer.modules.tid1500reader
       except AttributeError as exc:
-        logging.debug('Unable to find CLI module tid1500reader, unable to load SR TID1500 object: %s ' % exc.message)
+        logging.debug('Unable to find CLI module tid1500reader, unable to load SR TID1500 object: %s ' % str(exc))
         self.cleanup()
         return False
 


### PR DESCRIPTION
DICOMSegmentationPlugin did not report any error when the conversion failed (it raised an exception, but the Python wrapper ignores exceptions).

Also fixed capturing of the exception message: in Python3, exception does not have message attribute anymore.