### PR TITLE
COMP: Support bundling in custom application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,18 +18,22 @@ set(MODULE_NAME QuantitativeReporting)
 find_package(Slicer REQUIRED)
 include(${Slicer_USE_FILE})
 
-find_package(SlicerDevelopmentToolbox REQUIRED)
-find_package(DCMQI REQUIRED)
-find_package(PETDICOMExtension REQUIRED)
+set(DEPENDENCIES_ADDITIONAL_MODULE_PATHS)
 
-set(DEPENDENCIES_ADDITIONAL_MODULE_PATHS
-  ${SlicerDevelopmentToolbox_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}
-  ${SlicerDevelopmentToolbox_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}
-  ${SlicerDevelopmentToolbox_DIR}/${Slicer_CLIMODULES_LIB_DIR}
-  ${PETDICOMExtension_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}
-  ${PETDICOMExtension_DIR}/${Slicer_CLIMODULES_LIB_DIR}
-  ${DCMQI_DIR}/bin
-  )
+if(NOT Slicer_SOURCE_DIR)
+  find_package(SlicerDevelopmentToolbox REQUIRED)
+  find_package(DCMQI REQUIRED)
+  find_package(PETDICOMExtension REQUIRED)
+
+  list(APPEND DEPENDENCIES_ADDITIONAL_MODULE_PATHS
+    ${SlicerDevelopmentToolbox_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}
+    ${SlicerDevelopmentToolbox_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}
+    ${SlicerDevelopmentToolbox_DIR}/${Slicer_CLIMODULES_LIB_DIR}
+    ${PETDICOMExtension_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}
+    ${PETDICOMExtension_DIR}/${Slicer_CLIMODULES_LIB_DIR}
+    ${DCMQI_DIR}/bin
+    )
+endif()
 
 add_subdirectory(DICOMPlugins)
 add_subdirectory(QuantitativeReporting)


### PR DESCRIPTION
Since the "<extension_name>Config.cmake" module is not available when
bundling extension sources, this commit excludes the corresponding
requirements.

It also skips the setting of DEPENDENCIES_ADDITIONAL_MODULE_PATHS
because modules associated with the SlicerDevelopmentToolbox, DCMQI
and PETDICOMExtension extensions are built along side the QuantitativeReporting
ones.