### PR TITLE
Fixes deletion of nested tempdir

### DIFF
--- a/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -461,7 +461,7 @@ class DICOMSegmentationExporter(ModuleLogicMixin):
     self.segmentationNode = segmentationNode
     self.contentCreatorName = contentCreatorName if contentCreatorName else "Slicer"
 
-    self.tempDir = os.path.join(slicer.util.tempDirectory(), self.currentDateTime)
+    self.tempDir = slicer.util.tempDirectory()
     os.mkdir(self.tempDir)
 
   def cleanup(self):


### PR DESCRIPTION
By default `slicer.util.tempDirectory()` already contains the current timestamp - the additional subdirectory `self.currentDateTime` in `self.tempdir` leaves you over time with a collection of empty `slicer.util.tempDirectory()` (cf. image). Despite they are in a temp directory, I think it is avoidable ;-)

![image](https://user-images.githubusercontent.com/24655255/204035956-d44f1f46-1343-424c-bd81-a3fe27b30b99.png)
