### PR TITLE
Add warning if terminology information is missing in segment (fixes issue #267)

### DIFF
--- a/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -691,8 +691,7 @@ class DICOMSegmentationExporter(ModuleLogicMixin):
     segmentData["SegmentedPropertyTypeCodeSequence"] = self.getJSONFromVtkSlicerTerminology(typeObject)
 
     modifierObject = terminologyEntry.GetTypeModifierObject()
-    modifierObject_valid = modifierObject is not None and self.isTerminologyInformationValid(modifierObject)
-    if modifierObject_valid:
+    if modifierObject is not None and self.isTerminologyInformationValid(modifierObject):
       segmentData["SegmentedPropertyTypeModifierCodeSequence"] = self.getJSONFromVtkSlicerTerminology(modifierObject)
 
     return segmentData


### PR DESCRIPTION
Fixes issue #267 

Additionally, remove unnessecary mkdir() call since directory is created already by Slicer.util