### PR TITLE
ENH: Replace deprecated SetMasterRepresentationName

### DIFF
--- a/DICOMPlugins/DICOMM3DPlugin.py
+++ b/DICOMPlugins/DICOMM3DPlugin.py
@@ -144,7 +144,7 @@ class DICOMM3DPluginClass(DICOMPluginBase):
     #Setup converters for further export to labelmap or model representations 
     vtkSegConverter = vtkSegmentationCore.vtkSegmentationConverter
     segmentation = vtkSegmentationCore.vtkSegmentation()
-    segmentation.SetMasterRepresentationName(vtkSegConverter.GetSegmentationClosedSurfaceRepresentationName())
+    segmentation.SetSourceRepresentationName(vtkSegConverter.GetSegmentationClosedSurfaceRepresentationName())
     segmentation.CreateRepresentation(vtkSegConverter.GetSegmentationBinaryLabelmapRepresentationName(), True)
     segmentationNode.SetAndObserveSegmentation(segmentation)
     

--- a/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -291,7 +291,7 @@ class DICOMSegmentationPluginClass(DICOMPluginBase):
 
     vtkSegConverter = vtkSegmentationCore.vtkSegmentationConverter
     segmentation = vtkSegmentationCore.vtkSegmentation()
-    segmentation.SetMasterRepresentationName(vtkSegConverter.GetSegmentationBinaryLabelmapRepresentationName())
+    segmentation.SetSourceRepresentationName(vtkSegConverter.GetSegmentationBinaryLabelmapRepresentationName())
     segmentation.CreateRepresentation(vtkSegConverter.GetSegmentationClosedSurfaceRepresentationName(), True)
     segmentationNode.SetAndObserveSegmentation(segmentation)
 


### PR DESCRIPTION
This commit replaces SetMasterRepresentationName (deprecated) by the new SetSourceRepresentationName in response to the following warning when using the module.

```
[VTK] Warning: In vtkSegmentation.h, line 511
[VTK] vtkSegmentation (0x45d028c0): vtkSegmentation::SetMasterRepresentationName() method is deprecated, please use SetSourceRepresentationName method instead
```