### PR TITLE
BUG: fall back to deprecated method

### DIFF
--- a/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -138,8 +138,13 @@ class DICOMSegmentationPluginClass(DICOMPluginBase):
       categoryContextName = "Segmentation category and type - DICOM master list"
 
     anatomicContextName = loadable.name
-    if not terminologiesLogic.LoadRegionContextFromSegmentDescriptorFile(anatomicContextName, metaFileName):
-      anatomicContextName = "Anatomic codes - DICOM master list"
+    try:
+      if not terminologiesLogic.LoadRegionContextFromSegmentDescriptorFile(anatomicContextName, metaFileName):
+        anatomicContextName = "Anatomic codes - DICOM master list"
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      if not terminologiesLogic.LoadAnatomicContextFromSegmentDescriptorFile(anatomicContextName, metaFileName):
+        anatomicContextName = "Anatomic codes - DICOM master list"
 
     with open(metaFileName) as metaFile:
       data = json.load(metaFile)


### PR DESCRIPTION
Slicer 5.8.1 stable does not have the backward compatible API, breaking DICOM SEG load

Re https://github.com/Slicer/Slicer/issues/8324 #282

@lenagiebeler this should fix the issue you identified! Thank you for bringing this up.