### PR TITLE
BUG: Update Terminologies API to work with both latest and older Slicer versions

### DIFF
--- a/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -723,12 +723,22 @@ class DICOMSegmentationExporter(ModuleLogicMixin):
   def createJSONFromRegionContext(self, terminologyEntry):
     segmentData = dict()
 
-    regionObject = terminologyEntry.GetAnatomicRegionObject()
+    try:
+      regionObject = terminologyEntry.GetRegionObject()
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      regionObject = terminologyEntry.GetAnatomicRegionObject()
+
     if regionObject is None or not self.isTerminologyInformationValid(regionObject):
       return {}
     segmentData["AnatomicRegionSequence"] = self.getJSONFromVtkSlicerTerminology(regionObject)
 
-    regionModifierObject = terminologyEntry.GetAnatomicRegionModifierObject()
+    try:
+      regionModifierObject = terminologyEntry.GetRegionModifierObject()
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      regionModifierObject = terminologyEntry.GetAnatomicRegionModifierObject()
+
     if regionModifierObject is not None and self.isTerminologyInformationValid(regionModifierObject):
       segmentData["AnatomicRegionModifierSequence"] = self.getJSONFromVtkSlicerTerminology(regionModifierObject)
     return segmentData

--- a/QuantitativeReporting/QRCustomizations/CustomSegmentStatistics.py
+++ b/QuantitativeReporting/QRCustomizations/CustomSegmentStatistics.py
@@ -81,12 +81,22 @@ class CustomSegmentStatisticsLogic(SegmentStatisticsLogic):
   def createJSONFromAnatomicContext(self, terminologyEntry):
     segmentData = dict()
 
-    regionObject = terminologyEntry.GetAnatomicRegionObject()
+    try:
+      regionObject = terminologyEntry.GetRegionObject()
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      regionObject = terminologyEntry.GetAnatomicRegionObject()
+
     if regionObject is None or not self.isTerminologyInformationValid(regionObject):
       return {}
     segmentData["AnatomicRegionSequence"] = self.getJSONFromVTKSlicerTerminology(regionObject)
 
-    regionModifierObject = terminologyEntry.GetAnatomicRegionModifierObject()
+    try:
+      regionModifierObject = terminologyEntry.GetRegionModifierObject()
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      regionModifierObject = terminologyEntry.GetAnatomicRegionModifierObject()
+
     if regionModifierObject is not None and self.isTerminologyInformationValid(regionModifierObject):
       segmentData["AnatomicRegionModifierSequence"] = self.getJSONFromVTKSlicerTerminology(regionModifierObject)
     return segmentData

--- a/QuantitativeReporting/QRUtils/htmlReport.py
+++ b/QuantitativeReporting/QRUtils/htmlReport.py
@@ -371,8 +371,15 @@ class HTMLReportCreator(ScreenShotHelper):
   def getTerminologyInformation(self, segment):
     terminologyEntry = DICOMSegmentationExporter.getDeserializedTerminologyEntry(segment)
     catModifier = terminologyEntry.GetTypeModifierObject ().GetCodeMeaning()
-    anatomicRegion = terminologyEntry.GetAnatomicRegionObject().GetCodeMeaning()
-    anatomicRegionModifier = terminologyEntry.GetAnatomicRegionModifierObject ().GetCodeMeaning()
+
+    try:
+      anatomicRegion = terminologyEntry.GetRegionObject().GetCodeMeaning()
+      anatomicRegionModifier = terminologyEntry.GetRegionModifierObject ().GetCodeMeaning()
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      anatomicRegion = terminologyEntry.GetAnatomicRegionObject().GetCodeMeaning()
+      anatomicRegionModifier = terminologyEntry.GetAnatomicRegionModifierObject ().GetCodeMeaning()
+
     html = '''
       <table border=0 width='100%' cellPadding=3 cellSpacing=0>
         {}{}{}{}{}


### PR DESCRIPTION
fixes #285

I'll also add deprecated backward-compatibility methods to Slicer core to avoid potential errors like these elsewhere.
