### PR TITLE
Replace deprecated pydicom function

### DIFF
--- a/DICOMPlugins/DICOMM3DPlugin.py
+++ b/DICOMPlugins/DICOMM3DPlugin.py
@@ -64,14 +64,14 @@ class DICOMM3DPluginClass(DICOMPluginBase):
 
   def getFrameOfReferenceUID(self, candidateFile):
     """Returns the frame of referenceUID for the given loadable"""
-    dcm = pydicom.read_file(candidateFile)
+    dcm = pydicom.dcmread(candidateFile)
     if hasattr(dcm, "FrameOfReferenceUID"):
       return dcm.FrameOfReferenceUID
     else:
       return 'Unnamed FrameOfReferenceUID'
 
   def getEncapsulatedDocumentAttributes(self, candidateFile):
-    dcm = pydicom.read_file(candidateFile)
+    dcm = pydicom.dcmread(candidateFile)
     encapsulatedDocument = b''
     encapsulatedDocumentLength = 0
     if hasattr(dcm, "EncapsulatedDocument"):

--- a/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/DICOMPlugins/DICOMTID1500Plugin.py
@@ -43,7 +43,7 @@ class DICOMTID1500PluginClass(DICOMPluginBase, ModuleLogicMixin):
     loadables = []
 
     for cFile in files:
-      dataset = pydicom.read_file(cFile)
+      dataset = pydicom.dcmread(cFile)
 
       uid = self.getDICOMValue(dataset, "SOPInstanceUID")
       if uid == "":
@@ -142,7 +142,7 @@ class DICOMTID1500PluginClass(DICOMPluginBase, ModuleLogicMixin):
 
   def getDateTime(self, uid):
     filename = slicer.dicomDatabase.fileForInstance(uid)
-    dataset = pydicom.read_file(filename)
+    dataset = pydicom.dcmread(filename)
     if hasattr(dataset, 'SeriesDate') and hasattr(dataset, "SeriesTime"):
       date = dataset.SeriesDate
       time = dataset.SeriesTime
@@ -275,7 +275,7 @@ class DICOMTID1500PluginClass(DICOMPluginBase, ModuleLogicMixin):
       rwvmPlugin = slicer.modules.dicomPlugins["DICOMRWVMPlugin"]()
       rwvmFile = rwvmFiles[0]
       logging.debug("Reading RWVM from " + rwvmFile)
-      rwvmDataset = pydicom.read_file(rwvmFile)
+      rwvmDataset = pydicom.dcmread(rwvmFile)
       if hasattr(rwvmDataset, "ReferencedSeriesSequence"):
         if hasattr(rwvmDataset.ReferencedSeriesSequence[0], "SeriesInstanceUID"):
           if rwvmDataset.ReferencedSeriesSequence[0].SeriesInstanceUID == segLoadable.referencedSeriesUID:
@@ -383,7 +383,7 @@ class DICOMTID1500PluginClass(DICOMPluginBase, ModuleLogicMixin):
     """
 
     srFilePath = slicer.dicomDatabase.fileForInstance(srUID)
-    sr = pydicom.read_file(srFilePath)
+    sr = pydicom.dcmread(srFilePath)
 
     if not self.isConcept(sr, "imagingMeasurementReport"):
       return sr
@@ -439,7 +439,7 @@ class DICOMTID1500PluginClass(DICOMPluginBase, ModuleLogicMixin):
       if not referenceFilePath:
         raise Exception(f"Referenced image is not found in the database (referencedSOPInstanceUID={measurement['referencedSOPInstanceUID']}). Polyline point positions cannot be determined in 3D.")
 
-      reference = pydicom.read_file(referenceFilePath)
+      reference = pydicom.dcmread(referenceFilePath)
       origin = numpy.array(reference.ImagePositionPatient)
       alongColumnVector = numpy.array(reference.ImageOrientationPatient[:3])
       alongRowVector = numpy.array(reference.ImageOrientationPatient[3:])
@@ -462,7 +462,7 @@ class DICOMLongitudinalTID1500PluginClass(DICOMTID1500PluginClass):
     loadables = []
 
     for cFile in files:
-      dataset = pydicom.read_file(cFile)
+      dataset = pydicom.dcmread(cFile)
 
       uid = self.getDICOMValue(dataset, "SOPInstanceUID")
       if uid == "":
@@ -502,7 +502,7 @@ class DICOMLongitudinalTID1500PluginClass(DICOMTID1500PluginClass):
       foundSRs = []
       for s in series:
         srFile = self.fileForSeries(s)
-        tempDCM = pydicom.read_file(srFile)
+        tempDCM = pydicom.dcmread(srFile)
         if self.isDICOMTID1500(tempDCM):
           foundSRs.append(srFile)
           otherSRDatasets.append(tempDCM)

--- a/DICOMPlugins/base/DICOMPluginBase.py
+++ b/DICOMPlugins/base/DICOMPluginBase.py
@@ -59,7 +59,7 @@ class DICOMPluginBase(DICOMPlugin):
   def addReferences(self, loadable):
     """Puts a list of the referenced UID into the loadable for use
     in the node if this is loaded."""
-    dcm = pydicom.read_file(loadable.files[0])
+    dcm = pydicom.dcmread(loadable.files[0])
     loadable.referencedInstanceUIDs = []
     self._addReferencedSeries(loadable, dcm)
     self._addReferencedImages(loadable, dcm)
@@ -69,7 +69,7 @@ class DICOMPluginBase(DICOMPlugin):
     if hasattr(dcm, "ReferencedSeriesSequence"):
       if hasattr(dcm.ReferencedSeriesSequence[0], "SeriesInstanceUID"):
         for f in slicer.dicomDatabase.filesForSeries(dcm.ReferencedSeriesSequence[0].SeriesInstanceUID):
-          refDCM = pydicom.read_file(f)
+          refDCM = pydicom.dcmread(f)
           loadable.referencedInstanceUIDs.append(refDCM.SOPInstanceUID)
         loadable.referencedSeriesUID = dcm.ReferencedSeriesSequence[0].SeriesInstanceUID
 
@@ -79,4 +79,4 @@ class DICOMPluginBase(DICOMPlugin):
         if hasattr(item, "ReferencedSOPInstanceUID"):
           loadable.referencedInstanceUIDs.append(item.ReferencedSOPInstanceUID)
           # TODO: what to do with the SeriesInstanceUID?
-          # refDCM = pydicom.read_file(slicer.dicomDatabase.fileForInstance(item.ReferencedSOPInstanceUID))
+          # refDCM = pydicom.dcmread(slicer.dicomDatabase.fileForInstance(item.ReferencedSOPInstanceUID))


### PR DESCRIPTION
Replace deprecated function `pydicom.read_file()` by `pydicom.dcmread()`, cf.:
https://github.com/pydicom/pydicom/pull/506

The extension is currently not functional with preview version 3DSlicer 5.9, since in there python 3.11 will install `pydicom>=3.0` by default. This PR fixes this issue.